### PR TITLE
Release tweaks

### DIFF
--- a/Globals.h
+++ b/Globals.h
@@ -5,5 +5,5 @@
 namespace Globals {
   const std::string PluginName = "RBRCountdown";
   const std::string PluginsFolder = ".\\Plugins";
-  const std::string PluginFolder = PluginsFolder + "\\countdown";
+  const std::string PluginFolder = PluginsFolder + "\\" + PluginName;
 }

--- a/Plugin.h
+++ b/Plugin.h
@@ -38,17 +38,12 @@ public:
     LogUtil::ToFile("Destroying Plugin " + Globals::PluginName + ".");
   }
 
-  virtual const char* GetName(void) {
-    LogUtil::ToFile("GetName");
-
-    RBRAPI_InitializeObjReferences();
-
-    Countdown::InitCountdown();
-
-    //auto gtcDirect3DBeginScene = new DetourXS((LPVOID)0x0040E880, ::CustomRBRDirectXBeginScene, TRUE);
-    //Func_OrigRBRDirectXBeginScene = (tRBRDirectXBeginScene)gtcDirect3DBeginScene->GetTrampoline();
-
+  virtual const char* GetName(void) {    
     if(Func_OrigRBRDirectXEndScene == nullptr) {
+      LogUtil::ToFile("Initializing the plugin");
+      RBRAPI_InitializeObjReferences();
+      Countdown::InitCountdown();
+
       auto gtcDirect3DEndScene = new DetourXS((LPVOID)0x0040E890, ::CustomRBRDirectXEndScene, TRUE);
       Func_OrigRBRDirectXEndScene = (tRBRDirectXEndScene)gtcDirect3DEndScene->GetTrampoline();
     }

--- a/Plugin.h
+++ b/Plugin.h
@@ -40,6 +40,7 @@ public:
 
   virtual const char* GetName(void) {    
     if(Func_OrigRBRDirectXEndScene == nullptr) {
+      // Do the initialization and texture creation only once because RBR may call GetName several times
       LogUtil::ToFile("Initializing the plugin");
       RBRAPI_InitializeObjReferences();
       Countdown::InitCountdown();

--- a/RBRTestPlugin.vcxproj
+++ b/RBRTestPlugin.vcxproj
@@ -19,12 +19,13 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
@@ -65,6 +66,7 @@
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
     </ClCompile>
     <Link>
       <OutputFile>$(OutDir)$(TargetName).dll</OutputFile>
@@ -86,22 +88,29 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <DebugInformationFormat>None</DebugInformationFormat>
       <LanguageStandard>stdcpp17</LanguageStandard>
-      <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
+      <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <BasicRuntimeChecks>Default</BasicRuntimeChecks>
-      <Optimization>Disabled</Optimization>
+      <Optimization>MaxSpeed</Optimization>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <OmitFramePointers>true</OmitFramePointers>
+      <WholeProgramOptimization>true</WholeProgramOptimization>
+      <StringPooling>true</StringPooling>
     </ClCompile>
     <Link>
       <OutputFile>$(OutDir)$(TargetName).dll</OutputFile>
       <ModuleDefinitionFile>RBRTestPlugin.def</ModuleDefinitionFile>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <ImportLibrary>$(OutDir)RBRTestPlugin.lib</ImportLibrary>
       <TargetMachine>MachineX86</TargetMachine>
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/SamplePlug1.sln
+++ b/SamplePlug1.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.4.33103.184
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.32228.343
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "SamplePlug1", "RBRTestPlugin.vcxproj", "{DFCA2423-44B8-4A35-A380-7247D9CFCE30}"
 EndProject
@@ -10,10 +10,10 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{DFCA2423-44B8-4A35-A380-7247D9CFCE30}.Debug|x86.ActiveCfg = Release|Win32
-		{DFCA2423-44B8-4A35-A380-7247D9CFCE30}.Debug|x86.Build.0 = Release|Win32
-		{DFCA2423-44B8-4A35-A380-7247D9CFCE30}.Release|x86.ActiveCfg = Debug|Win32
-		{DFCA2423-44B8-4A35-A380-7247D9CFCE30}.Release|x86.Build.0 = Debug|Win32
+		{DFCA2423-44B8-4A35-A380-7247D9CFCE30}.Debug|x86.ActiveCfg = Debug|Win32
+		{DFCA2423-44B8-4A35-A380-7247D9CFCE30}.Debug|x86.Build.0 = Debug|Win32
+		{DFCA2423-44B8-4A35-A380-7247D9CFCE30}.Release|x86.ActiveCfg = Release|Win32
+		{DFCA2423-44B8-4A35-A380-7247D9CFCE30}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Utils/INIUtil.h
+++ b/Utils/INIUtil.h
@@ -17,9 +17,10 @@ namespace INIUtil {
     float Get(string section, string name, float default);
     bool Get(string section, string name, bool default);
 
-    void Save();
+    void Save(bool forceSave = false);
 
   private:
+    bool defaultOptionsSet;
     string filePath;
     CSimpleIniA ini;
   };

--- a/Utils/LogUtil.cpp
+++ b/Utils/LogUtil.cpp
@@ -60,4 +60,10 @@ namespace LogUtil {
   void LastExceptionToFile(string source) {
     ToFile(source + " Exception: " + lastExceptionString());
   }
+
+  std::string ErrNoToString(int errorno) {
+    char szErrorMsg[256] = { 0 };
+    strerror_s(szErrorMsg, errno);
+    return std::string(szErrorMsg) + " (" + std::to_string(errorno) + ")";
+  }
 }

--- a/Utils/LogUtil.h
+++ b/Utils/LogUtil.h
@@ -16,4 +16,5 @@ namespace LogUtil {
   void ToFile(const char* message);
   void ToScreen(const char* message);
   void LastExceptionToFile(string source);
+  std::string ErrNoToString(int errorno);
 }


### PR DESCRIPTION
- VC++ Project settings fix (release and debug options were vice-versa where Release compilation actually produced debug binary and vice-versa).
- Small INI file tweaks (true/false case-insensitive and accept "1" and "0" also as a boolean INI option value). Also bug fix in GetFloat ini method because it used accidentally int variable
- GetName method fixed to initialize textures only once (RBR may call GetName several times, so the original code wasted resources in that case)
- Changed the Globals.h to use ".\\Plugins\\RBRCountdown\\" folder as a configuration and texture source (it is more logical to have the subfolder with the same name as the actual plugin file (most other plugins use this logic also).
- Tweaked project settings to make it use VC++ optimizations in Release build
